### PR TITLE
feat: Added Java 9 Modules Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,11 @@ tasks {
     test {
         useJUnitPlatform()
     }
+    jar {
+        manifest {
+            attributes("Automatic-Module-Name" to "team.unnamed.inject")
+        }
+    }
 }
 
 val repositoryName: String by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=team.unnamed
-version=1.0.1
+version=1.0.2
 description=Lightweight and fast runtime dependency injection library for Java 8+
 
 repositoryName=unnamedRepository


### PR DESCRIPTION
Added support for Java 9+ modular applications without losing compatibility with Java 8 by using [Automatic Modules](https://www.geeksforgeeks.org/automatic-modules-in-java/)

Without this change it would not be possible to use unnamed/inject in a modular project, since its packages would be in the [Unnamed Module](https://www.geeksforgeeks.org/unnamed-module-in-java/)