### PR TITLE
BREAKING! Remove `javax.inject`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,6 @@ repositories {
 }
 
 dependencies {
-    api("javax.inject:javax.inject:1")
-
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
 }

--- a/docs/config/bindings.md
+++ b/docs/config/bindings.md
@@ -12,7 +12,7 @@ provider is called
 ### Direct Binding
 
 A direct binding is a binding of a type to a provider function
-(`javax.inject.Provider<T>`)
+(`team.unnamed.inject.Provider<T>`)
 
 ```java
 binder.bind(Database.class).toProvider(() -> {

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -52,7 +52,7 @@ and re-usable
 Here is an example that uses dependency injection with `unnamed/inject`
 
 ```java
-import javax.inject.Inject;
+import team.unnamed.inject.Inject;
 
 public class UserDao {
     

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 Welcome to the `inject` documentation
 
 `unnamed/inject` is a zero-dependency, lightweight and fast runtime dependency
-injection library compatible with the JSR-330 specification for Java 8+
+injection library for Java 8+
 
 
 ### Features

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ Add the dependency
 
 ```kotlin
 dependencies {
-    implementation("team.unnamed:inject:1.0.2")
+    implementation("team.unnamed:inject:2.0.0")
 }
 ```
 
@@ -39,6 +39,6 @@ Add the dependency
 <dependency>
     <groupId>team.unnamed</groupId>
     <artifactId>inject</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
 </dependency>
 ```

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,7 @@
 [![Discord](https://img.shields.io/discord/683899335405994062)](https://discord.gg/xbba2fy)
 
 `unnamed/inject` is a zero-dependency, lightweight and fast runtime dependency
-injection library based on [Google's Guice](https://github.com/google/guice),
-compatible with the JSR-330 specification for Java 8+
+injection library based on [Google's Guice](https://github.com/google/guice) for Java 8+
 
 By not having to worry about manually injecting dependencies, this library
 will potentially increase your programming productivity

--- a/src/main/java/team/unnamed/inject/Binder.java
+++ b/src/main/java/team/unnamed/inject/Binder.java
@@ -10,7 +10,6 @@ import team.unnamed.inject.provision.std.generic.GenericProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.scope.Scopes;
 
-import javax.inject.Provider;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/team/unnamed/inject/Delegated.java
+++ b/src/main/java/team/unnamed/inject/Delegated.java
@@ -1,6 +1,5 @@
 package team.unnamed.inject;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/team/unnamed/inject/Inject.java
+++ b/src/main/java/team/unnamed/inject/Inject.java
@@ -1,0 +1,17 @@
+package team.unnamed.inject;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.FIELD;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({METHOD, CONSTRUCTOR, FIELD})
+public @interface Inject {
+}

--- a/src/main/java/team/unnamed/inject/Injector.java
+++ b/src/main/java/team/unnamed/inject/Injector.java
@@ -4,7 +4,6 @@ import team.unnamed.inject.impl.BinderImpl;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.key.TypeReference;
 
-import javax.inject.Provider;
 import java.util.Arrays;
 
 public interface Injector {

--- a/src/main/java/team/unnamed/inject/Module.java
+++ b/src/main/java/team/unnamed/inject/Module.java
@@ -5,7 +5,7 @@ package team.unnamed.inject;
  * configuration. A module is usually used to bind abstractions
  * (interfaces, abstract classes) to implementations (concrete
  * classes). To just add a scope to a class, you can use scope
- * annotations like {@link javax.inject.Singleton}.
+ * annotations like {@link Singleton}.
  * You can also use annotations to bind abstractions to implementations
  * like {@link Targetted} and {@link ProvidedBy}.
  *
@@ -13,7 +13,7 @@ package team.unnamed.inject;
  *
  * <p>You can also create provider methods (methods used as providers) and
  * annotate it with {@link Provides}. Annotate the method with
- * {@link javax.inject.Inject} if the object creation has dependencies.</p>
+ * {@link Inject} if the object creation has dependencies.</p>
  *
  * <p>There's an extension for users to create bindings in a pretty way
  * using {@link AbstractModule}.</p>

--- a/src/main/java/team/unnamed/inject/Named.java
+++ b/src/main/java/team/unnamed/inject/Named.java
@@ -1,0 +1,14 @@
+package team.unnamed.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Named {
+
+    String value() default "";
+
+}

--- a/src/main/java/team/unnamed/inject/ProvidedBy.java
+++ b/src/main/java/team/unnamed/inject/ProvidedBy.java
@@ -1,6 +1,5 @@
 package team.unnamed.inject;
 
-import javax.inject.Provider;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/team/unnamed/inject/Provider.java
+++ b/src/main/java/team/unnamed/inject/Provider.java
@@ -1,0 +1,7 @@
+package team.unnamed.inject;
+
+public interface Provider<T> {
+
+    T get();
+
+}

--- a/src/main/java/team/unnamed/inject/Qualifier.java
+++ b/src/main/java/team/unnamed/inject/Qualifier.java
@@ -1,0 +1,13 @@
+package team.unnamed.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Qualifier {
+}

--- a/src/main/java/team/unnamed/inject/Scope.java
+++ b/src/main/java/team/unnamed/inject/Scope.java
@@ -1,0 +1,13 @@
+package team.unnamed.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Scope {
+}

--- a/src/main/java/team/unnamed/inject/Singleton.java
+++ b/src/main/java/team/unnamed/inject/Singleton.java
@@ -1,0 +1,11 @@
+package team.unnamed.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Singleton {
+}

--- a/src/main/java/team/unnamed/inject/impl/AnnotationScanner.java
+++ b/src/main/java/team/unnamed/inject/impl/AnnotationScanner.java
@@ -1,6 +1,8 @@
 package team.unnamed.inject.impl;
 
 import team.unnamed.inject.ProvidedBy;
+import team.unnamed.inject.Provider;
+import team.unnamed.inject.Singleton;
 import team.unnamed.inject.Targetted;
 import team.unnamed.inject.key.Key;
 import team.unnamed.inject.key.TypeReference;
@@ -9,8 +11,6 @@ import team.unnamed.inject.provision.StdProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.scope.Scopes;
 
-import javax.inject.Provider;
-import javax.inject.Singleton;
 import java.lang.reflect.Modifier;
 
 /**

--- a/src/main/java/team/unnamed/inject/impl/Annotations.java
+++ b/src/main/java/team/unnamed/inject/impl/Annotations.java
@@ -1,8 +1,8 @@
 package team.unnamed.inject.impl;
 
+import team.unnamed.inject.Named;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Named;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/src/main/java/team/unnamed/inject/impl/BinderImpl.java
+++ b/src/main/java/team/unnamed/inject/impl/BinderImpl.java
@@ -2,6 +2,7 @@ package team.unnamed.inject.impl;
 
 import team.unnamed.inject.Binder;
 import team.unnamed.inject.Module;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.error.BindingException;
 import team.unnamed.inject.error.ErrorAttachableImpl;
 import team.unnamed.inject.key.Key;
@@ -13,7 +14,6 @@ import team.unnamed.inject.provision.std.MethodAsProvider;
 import team.unnamed.inject.provision.std.generic.impl.TypeReferenceGenericProvider;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Provider;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/team/unnamed/inject/impl/BindingBuilderImpl.java
+++ b/src/main/java/team/unnamed/inject/impl/BindingBuilderImpl.java
@@ -1,13 +1,12 @@
 package team.unnamed.inject.impl;
 
 import team.unnamed.inject.Binder;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.key.Key;
 import team.unnamed.inject.key.TypeReference;
 import team.unnamed.inject.provision.Providers;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.util.Validate;
-
-import javax.inject.Provider;
 
 class BindingBuilderImpl<T> implements
         Binder.QualifiedBindingBuilder<T>,

--- a/src/main/java/team/unnamed/inject/impl/InjectorImpl.java
+++ b/src/main/java/team/unnamed/inject/impl/InjectorImpl.java
@@ -1,6 +1,7 @@
 package team.unnamed.inject.impl;
 
 import team.unnamed.inject.Injector;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.error.InjectionException;
 import team.unnamed.inject.key.InjectedKey;
 import team.unnamed.inject.key.Key;
@@ -11,7 +12,6 @@ import team.unnamed.inject.resolve.solution.InjectableConstructor;
 import team.unnamed.inject.resolve.solution.InjectableMember;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Provider;
 import java.util.List;
 
 public class InjectorImpl implements Injector {

--- a/src/main/java/team/unnamed/inject/impl/LinkedBuilder.java
+++ b/src/main/java/team/unnamed/inject/impl/LinkedBuilder.java
@@ -1,6 +1,7 @@
 package team.unnamed.inject.impl;
 
 import team.unnamed.inject.Binder;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.assisted.ValueFactory;
 import team.unnamed.inject.assisted.provision.ToFactoryProvider;
 import team.unnamed.inject.key.Key;
@@ -9,8 +10,6 @@ import team.unnamed.inject.provision.Providers;
 import team.unnamed.inject.provision.std.generic.GenericProvider;
 import team.unnamed.inject.provision.std.generic.ToGenericProvider;
 import team.unnamed.inject.util.Validate;
-
-import javax.inject.Provider;
 
 public interface LinkedBuilder<R, T> extends Binder.Linked<R, T> {
 

--- a/src/main/java/team/unnamed/inject/key/Key.java
+++ b/src/main/java/team/unnamed/inject/key/Key.java
@@ -1,10 +1,10 @@
 package team.unnamed.inject.key;
 
+import team.unnamed.inject.Qualifier;
 import team.unnamed.inject.key.Types.CompositeType;
 import team.unnamed.inject.util.ElementFormatter;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Qualifier;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Objects;
@@ -169,7 +169,7 @@ public final class Key<T> implements CompositeType, Serializable {
      *     marked with @Marker
      * </pre>
      *
-     * If a class name starts with {@code java} or {@code javax},
+     * If a class name starts with {@code java},
      * it isn't used, the used name is now {@link Class#getSimpleName()}
      *
      * @return The key information as string

--- a/src/main/java/team/unnamed/inject/multibinding/CollectionBoundProvider.java
+++ b/src/main/java/team/unnamed/inject/multibinding/CollectionBoundProvider.java
@@ -1,12 +1,12 @@
 package team.unnamed.inject.multibinding;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.key.Key;
 import team.unnamed.inject.key.TypeReference;
 import team.unnamed.inject.provision.StdProvider;
 
-import javax.inject.Provider;
 import java.util.Collection;
 import java.util.Collections;
 

--- a/src/main/java/team/unnamed/inject/multibinding/CollectionMultiBindingBuilderImpl.java
+++ b/src/main/java/team/unnamed/inject/multibinding/CollectionMultiBindingBuilderImpl.java
@@ -1,6 +1,7 @@
 package team.unnamed.inject.multibinding;
 
 import team.unnamed.inject.Binder;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.BinderImpl;
 import team.unnamed.inject.impl.LinkedBuilder;
 import team.unnamed.inject.key.Key;
@@ -9,7 +10,6 @@ import team.unnamed.inject.provision.StdProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Provider;
 import java.util.Collection;
 
 /**

--- a/src/main/java/team/unnamed/inject/multibinding/MapBoundProvider.java
+++ b/src/main/java/team/unnamed/inject/multibinding/MapBoundProvider.java
@@ -1,11 +1,11 @@
 package team.unnamed.inject.multibinding;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.provision.Providers;
 import team.unnamed.inject.provision.StdProvider;
 
-import javax.inject.Provider;
 import java.util.Collections;
 import java.util.Map;
 

--- a/src/main/java/team/unnamed/inject/multibinding/MapMultiBindingBuilderImpl.java
+++ b/src/main/java/team/unnamed/inject/multibinding/MapMultiBindingBuilderImpl.java
@@ -1,6 +1,7 @@
 package team.unnamed.inject.multibinding;
 
 import team.unnamed.inject.Binder;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.BinderImpl;
 import team.unnamed.inject.impl.LinkedBuilder;
 import team.unnamed.inject.key.Key;
@@ -9,7 +10,6 @@ import team.unnamed.inject.provision.StdProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Provider;
 import java.util.Map;
 
 class MapMultiBindingBuilderImpl<K, V> implements Binder.MapMultiBindingBuilder<K, V> {

--- a/src/main/java/team/unnamed/inject/provision/DelegatingStdProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/DelegatingStdProvider.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.provision;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.BinderImpl;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
@@ -7,7 +8,6 @@ import team.unnamed.inject.key.Key;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Provider;
 import java.util.Objects;
 
 /**

--- a/src/main/java/team/unnamed/inject/provision/Providers.java
+++ b/src/main/java/team/unnamed/inject/provision/Providers.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.provision;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.key.Key;
@@ -9,8 +10,6 @@ import team.unnamed.inject.provision.std.LinkedProvider;
 import team.unnamed.inject.provision.std.ProviderTypeProvider;
 import team.unnamed.inject.provision.std.ScopedProvider;
 import team.unnamed.inject.util.Validate;
-
-import javax.inject.Provider;
 
 /**
  * Collection of static factory methods to create providers

--- a/src/main/java/team/unnamed/inject/provision/StdProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/StdProvider.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.provision;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.assisted.provision.ToFactoryProvider;
 import team.unnamed.inject.impl.BinderImpl;
 import team.unnamed.inject.impl.InjectorImpl;
@@ -7,8 +8,6 @@ import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.key.Key;
 import team.unnamed.inject.provision.std.ScopedProvider;
 import team.unnamed.inject.scope.Scope;
-
-import javax.inject.Provider;
 
 public abstract class StdProvider<T> implements Provider<T> {
 

--- a/src/main/java/team/unnamed/inject/provision/std/InstanceProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/std/InstanceProvider.java
@@ -1,11 +1,10 @@
 package team.unnamed.inject.provision.std;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.key.Key;
 import team.unnamed.inject.provision.StdProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.scope.Scopes;
-
-import javax.inject.Provider;
 
 /**
  * Represents an instance binding. The key is bound to a

--- a/src/main/java/team/unnamed/inject/provision/std/MethodAsProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/std/MethodAsProvider.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.provision.std;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.Provides;
 import team.unnamed.inject.error.BindingException;
 import team.unnamed.inject.error.ErrorAttachable;
@@ -13,7 +14,6 @@ import team.unnamed.inject.resolve.solution.InjectableMethod;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.scope.Scopes;
 
-import javax.inject.Provider;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/team/unnamed/inject/provision/std/ProviderTypeProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/std/ProviderTypeProvider.java
@@ -1,12 +1,11 @@
 package team.unnamed.inject.provision.std;
 
 import team.unnamed.inject.Injector;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.key.TypeReference;
 import team.unnamed.inject.provision.StdProvider;
-
-import javax.inject.Provider;
 
 /**
  * Represents a provider that gets instantiated the first

--- a/src/main/java/team/unnamed/inject/provision/std/ScopedProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/std/ScopedProvider.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.provision.std;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.key.Key;
@@ -7,8 +8,6 @@ import team.unnamed.inject.provision.Providers;
 import team.unnamed.inject.provision.StdProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.util.Validate;
-
-import javax.inject.Provider;
 
 /**
  * It's a provider wrapped. Maintains the

--- a/src/main/java/team/unnamed/inject/provision/std/generic/GenericProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/std/generic/GenericProvider.java
@@ -1,8 +1,7 @@
 package team.unnamed.inject.provision.std.generic;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.key.Key;
-
-import javax.inject.Provider;
 
 /**
  * It's (indirectly) a {@link Provider} for not-bound

--- a/src/main/java/team/unnamed/inject/provision/std/generic/ToGenericProvider.java
+++ b/src/main/java/team/unnamed/inject/provision/std/generic/ToGenericProvider.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.provision.std.generic;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.impl.BinderImpl;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
@@ -8,8 +9,6 @@ import team.unnamed.inject.provision.StdProvider;
 import team.unnamed.inject.provision.std.ScopedProvider;
 import team.unnamed.inject.scope.Scope;
 import team.unnamed.inject.util.Validate;
-
-import javax.inject.Provider;
 
 public class ToGenericProvider<T>
         extends ScopedProvider<T>

--- a/src/main/java/team/unnamed/inject/resolve/ConstructorResolver.java
+++ b/src/main/java/team/unnamed/inject/resolve/ConstructorResolver.java
@@ -1,10 +1,10 @@
 package team.unnamed.inject.resolve;
 
+import team.unnamed.inject.Inject;
 import team.unnamed.inject.error.ErrorAttachable;
 import team.unnamed.inject.key.TypeReference;
 import team.unnamed.inject.resolve.solution.InjectableConstructor;
 
-import javax.inject.Inject;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 

--- a/src/main/java/team/unnamed/inject/resolve/FieldResolver.java
+++ b/src/main/java/team/unnamed/inject/resolve/FieldResolver.java
@@ -1,12 +1,12 @@
 package team.unnamed.inject.resolve;
 
+import team.unnamed.inject.Inject;
 import team.unnamed.inject.InjectAll;
 import team.unnamed.inject.InjectIgnore;
 import team.unnamed.inject.key.InjectedKey;
 import team.unnamed.inject.key.TypeReference;
 import team.unnamed.inject.resolve.solution.InjectableField;
 
-import javax.inject.Inject;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +52,7 @@ public final class FieldResolver {
         ) {
             // iterate all fields, including private fields
             // exclude fields that aren't annotated with
-            // javax.inject.Inject
+            // team.unnamed.inject.Inject
             boolean injectAll = checking.isAnnotationPresent(InjectAll.class);
             for (Field field : checking.getDeclaredFields()) {
                 if (injectAll) {

--- a/src/main/java/team/unnamed/inject/resolve/KeyResolver.java
+++ b/src/main/java/team/unnamed/inject/resolve/KeyResolver.java
@@ -1,12 +1,12 @@
 package team.unnamed.inject.resolve;
 
+import team.unnamed.inject.Qualifier;
 import team.unnamed.inject.assisted.Assist;
 import team.unnamed.inject.impl.Annotations;
 import team.unnamed.inject.key.InjectedKey;
 import team.unnamed.inject.key.Key;
 import team.unnamed.inject.key.TypeReference;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;

--- a/src/main/java/team/unnamed/inject/resolve/MethodResolver.java
+++ b/src/main/java/team/unnamed/inject/resolve/MethodResolver.java
@@ -1,9 +1,9 @@
 package team.unnamed.inject.resolve;
 
+import team.unnamed.inject.Inject;
 import team.unnamed.inject.key.TypeReference;
 import team.unnamed.inject.resolve.solution.InjectableMethod;
 
-import javax.inject.Inject;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -58,7 +58,7 @@ public final class MethodResolver {
         ) {
             // Iterate all methods, including private methods
             // exclude methods that aren't annotated with
-            // javax.inject.Inject and add to the methods list,
+            // @Inject and add to the methods list,
             // not to the members list
             for (Method method : checking.getDeclaredMethods()) {
                 if (!method.isAnnotationPresent(annotation)) {

--- a/src/main/java/team/unnamed/inject/resolve/solution/InjectableConstructor.java
+++ b/src/main/java/team/unnamed/inject/resolve/solution/InjectableConstructor.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 /**
  * Represents an injectable constructor, a constructor
- * annotated with {@link javax.inject.Inject} or a
+ * annotated with {@link team.unnamed.inject.Inject} or a
  * constructor with no parameters.
  */
 public class InjectableConstructor implements InjectableMember {

--- a/src/main/java/team/unnamed/inject/resolve/solution/InjectableField.java
+++ b/src/main/java/team/unnamed/inject/resolve/solution/InjectableField.java
@@ -12,7 +12,7 @@ import java.lang.reflect.Modifier;
 import java.util.Objects;
 
 /**
- * Represents a Field annotated with {@link javax.inject.Inject}
+ * Represents a Field annotated with {@link team.unnamed.inject.Inject}
  * and that already has resolved a key, with its requirement level
  * defined too.
  */

--- a/src/main/java/team/unnamed/inject/resolve/solution/InjectableMethod.java
+++ b/src/main/java/team/unnamed/inject/resolve/solution/InjectableMethod.java
@@ -1,5 +1,6 @@
 package team.unnamed.inject.resolve.solution;
 
+import team.unnamed.inject.Inject;
 import team.unnamed.inject.impl.InjectorImpl;
 import team.unnamed.inject.impl.ProvisionStack;
 import team.unnamed.inject.key.InjectedKey;
@@ -14,7 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Represents a Method annotated with {@link javax.inject.Inject}
+ * Represents a Method annotated with {@link Inject}
  * and that already has resolved its parameter keys, with its
  * requirement level defined too.
  */

--- a/src/main/java/team/unnamed/inject/scope/LazySingletonScope.java
+++ b/src/main/java/team/unnamed/inject/scope/LazySingletonScope.java
@@ -1,8 +1,8 @@
 package team.unnamed.inject.scope;
 
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.provision.StdProvider;
 
-import javax.inject.Provider;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 

--- a/src/main/java/team/unnamed/inject/scope/Scope.java
+++ b/src/main/java/team/unnamed/inject/scope/Scope.java
@@ -1,6 +1,6 @@
 package team.unnamed.inject.scope;
 
-import javax.inject.Provider;
+import team.unnamed.inject.Provider;
 
 /**
  * Wraps providers

--- a/src/main/java/team/unnamed/inject/scope/ScopeScanner.java
+++ b/src/main/java/team/unnamed/inject/scope/ScopeScanner.java
@@ -1,8 +1,8 @@
 package team.unnamed.inject.scope;
 
+import team.unnamed.inject.Singleton;
 import team.unnamed.inject.util.Validate;
 
-import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ public final class ScopeScanner {
      *
      * <p>Note that this method doesn't require
      * the {@code annotationType} to be annotated
-     * with {@link javax.inject.Scope}</p>
+     * with {@link team.unnamed.inject.Scope}</p>
      */
     public void bind(Class<? extends Annotation> annotationType, Scope scope) {
         Validate.notNull(annotationType, "annotationType");

--- a/src/main/java/team/unnamed/inject/scope/Scopes.java
+++ b/src/main/java/team/unnamed/inject/scope/Scopes.java
@@ -1,6 +1,6 @@
 package team.unnamed.inject.scope;
 
-import javax.inject.Provider;
+import team.unnamed.inject.Provider;
 
 /**
  * Collection of built-in scopes

--- a/src/test/java/team/unnamed/inject/AssistedInjectTest.java
+++ b/src/test/java/team/unnamed/inject/AssistedInjectTest.java
@@ -7,8 +7,6 @@ import team.unnamed.inject.key.TypeReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-
 public class AssistedInjectTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/ComplexTypeVariableResolutionTest.java
+++ b/src/test/java/team/unnamed/inject/ComplexTypeVariableResolutionTest.java
@@ -4,8 +4,6 @@ import team.unnamed.inject.key.TypeReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-
 // test for issue reported by pixeldev (github.com/pixeldev)
 public class ComplexTypeVariableResolutionTest {
 

--- a/src/test/java/team/unnamed/inject/ConstructorInjectionTest.java
+++ b/src/test/java/team/unnamed/inject/ConstructorInjectionTest.java
@@ -3,8 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-
 public class ConstructorInjectionTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/CyclicInjectionTest.java
+++ b/src/test/java/team/unnamed/inject/CyclicInjectionTest.java
@@ -3,8 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-
 public class CyclicInjectionTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/GenericInjectionTest.java
+++ b/src/test/java/team/unnamed/inject/GenericInjectionTest.java
@@ -4,8 +4,6 @@ import team.unnamed.inject.key.TypeReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-
 public class GenericInjectionTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/InjectAllTest.java
+++ b/src/test/java/team/unnamed/inject/InjectAllTest.java
@@ -3,8 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Named;
-
 public class InjectAllTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/ManyProvidersInjectionTest.java
+++ b/src/test/java/team/unnamed/inject/ManyProvidersInjectionTest.java
@@ -3,9 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
-
 public class ManyProvidersInjectionTest {
 
     @Inject

--- a/src/test/java/team/unnamed/inject/MultiBindTest.java
+++ b/src/test/java/team/unnamed/inject/MultiBindTest.java
@@ -3,8 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/src/test/java/team/unnamed/inject/ProviderMethodsTest.java
+++ b/src/test/java/team/unnamed/inject/ProviderMethodsTest.java
@@ -3,9 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import java.util.UUID;
 
 public class ProviderMethodsTest {

--- a/src/test/java/team/unnamed/inject/ProviderTest.java
+++ b/src/test/java/team/unnamed/inject/ProviderTest.java
@@ -4,9 +4,6 @@ import team.unnamed.inject.error.InjectionException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
-
 public class ProviderTest {
 
     @Inject

--- a/src/test/java/team/unnamed/inject/QualifiedAssistedInjectTest.java
+++ b/src/test/java/team/unnamed/inject/QualifiedAssistedInjectTest.java
@@ -6,9 +6,6 @@ import team.unnamed.inject.assisted.ValueFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 public class QualifiedAssistedInjectTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/QualifiedBindingTest.java
+++ b/src/test/java/team/unnamed/inject/QualifiedBindingTest.java
@@ -3,9 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 public class QualifiedBindingTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/SingletonBindingTest.java
+++ b/src/test/java/team/unnamed/inject/SingletonBindingTest.java
@@ -3,7 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.UUID;
 
 public class SingletonBindingTest {

--- a/src/test/java/team/unnamed/inject/StaticInjectionTest.java
+++ b/src/test/java/team/unnamed/inject/StaticInjectionTest.java
@@ -3,8 +3,6 @@ package team.unnamed.inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-
 public class StaticInjectionTest {
 
     @Test

--- a/src/test/java/team/unnamed/inject/ToGenericProviderTest.java
+++ b/src/test/java/team/unnamed/inject/ToGenericProviderTest.java
@@ -5,7 +5,6 @@ import team.unnamed.inject.provision.std.generic.GenericProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 

--- a/src/test/java/team/unnamed/inject/explore/ProxiedFactoryProviderExploreTest.java
+++ b/src/test/java/team/unnamed/inject/explore/ProxiedFactoryProviderExploreTest.java
@@ -1,6 +1,7 @@
 package team.unnamed.inject.explore;
 
 import team.unnamed.inject.Injector;
+import team.unnamed.inject.Provider;
 import team.unnamed.inject.assisted.Assist;
 import team.unnamed.inject.assisted.Assisted;
 import team.unnamed.inject.assisted.ValueFactory;
@@ -8,8 +9,6 @@ import team.unnamed.inject.assisted.provision.ProxiedFactoryProvider;
 import team.unnamed.inject.key.Key;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import javax.inject.Provider;
 
 public class ProxiedFactoryProviderExploreTest {
 


### PR DESCRIPTION
This pull request removes the `javax.inject` dependency and adds our own equivalent interfaces and annotations
- This removes support for the JSR-330 standard
- `javax.inject` does not support Java 9 modules.
- Relocation becomes simpler *(only the `team.unnamed.inject` package will need to be relocated)*